### PR TITLE
lein2deps: add :compile-path to :paths when present

### DIFF
--- a/lein2deps.clj
+++ b/lein2deps.clj
@@ -51,7 +51,9 @@ Options:
           parsed (if (:eval opts)
                    (load-file project-clj)
                    (safe-parse project-clj))
-          {:keys [dependencies source-paths resource-paths]} parsed]
+          {:keys [dependencies source-paths resource-paths compile-path]} parsed]
       (pprint/pprint
-       {:paths (into (vec source-paths) resource-paths)
+       {:paths (cond-> (into (vec source-paths) resource-paths)
+                 compile-path
+                 (conj compile-path))
         :deps (into {} (map convert-dep) dependencies)}))))


### PR DESCRIPTION
This is necessary for making things work when a Leiningen project comes with some Java sources, for example (like Aleph :smile:). Note that this doesn't account for when `project.clj` relies on the default `:compile-path`. This is in line with how `lein2deps` treats `:source-paths` which happens to work fine because the default appears to be the same for both `deps.edn` and `project.clj`. Maybe we should account for this here? Then again, most projects probably don't need `:compile-path` so always including the default seems annoying, too. Instead, people could just be advised to add it explicitly to their `project.clj` even if it means repeating the default. WDYT?